### PR TITLE
Save the job before enqueueing it.

### DIFF
--- a/Sources/JobsRedisDriver/JobsRedisDriver.swift
+++ b/Sources/JobsRedisDriver/JobsRedisDriver.swift
@@ -58,9 +58,9 @@ extension JobsRedisDriver: JobsPersistenceLayer {
     public func set(key: String, jobStorage: JobStorage) -> EventLoopFuture<Void> {
         return database.newConnection(on: eventLoop).flatMap(to: (RedisData, RedisClient).self) { conn in
             let data = try JSONEncoder().encode(jobStorage).convertToRedisData()
-            return conn.lpush([try jobStorage.id.convertToRedisData()], into: key).transform(to: (data, conn))
+            return conn.set(jobStorage.id, to: data).transform(to: (data, conn))
         }.flatMap { data, conn in
-            return conn.set(jobStorage.id, to: data).transform(to: conn)
+            return conn.lpush([try jobStorage.id.convertToRedisData()], into: key).transform(to: conn)
         }.map { conn in
             return conn.close()
         }


### PR DESCRIPTION
The current code allows a situation when a job is enqueued and then dequeued before it’s saved. Then JobsRedisDriver.get(key:) fails to read it and the job is stuck in “processing”.