### PR TITLE
Test Application Start

### DIFF
--- a/Tests/JobsRedisDriverTests/JobsRedisDriverTests.swift
+++ b/Tests/JobsRedisDriverTests/JobsRedisDriverTests.swift
@@ -98,7 +98,14 @@ final class Promise: Job {
         context.logger.info("promise succeeded \(message)")
         return context.eventLoop.makeSucceededFuture(())
     }
+    
+    struct Deinit: Error { }
+
+    deinit {
+        self.promise.fail(Deinit())
+    }
 }
+
 
 final class Email: Job {
     struct Message: Codable, Equatable {

--- a/Tests/JobsRedisDriverTests/JobsRedisDriverTests.swift
+++ b/Tests/JobsRedisDriverTests/JobsRedisDriverTests.swift
@@ -74,7 +74,7 @@ final class JobsRedisDriverTests: XCTestCase {
             .dispatch(Promise.self, "test")
             .wait()
 
-        try XCTAssertEqual(promise.promise.futureResult.wait(), "test")
+        try XCTAssertEqual(promise.future.wait(), "test")
     }
 }
 
@@ -83,7 +83,11 @@ var hostname: String {
 }
 
 final class Promise: Job {
-    let promise: EventLoopPromise<String>
+    private let promise: EventLoopPromise<String>
+
+    var future: EventLoopFuture<String> {
+        self.promise.futureResult
+    }
 
     init(on eventLoop: EventLoop) {
         self.promise = eventLoop.makePromise()
@@ -94,8 +98,8 @@ final class Promise: Job {
         context.logger.info("promise succeeded \(message)")
         return context.eventLoop.makeSucceededFuture(())
     }
-
 }
+
 final class Email: Job {
     struct Message: Codable, Equatable {
         let to: String

--- a/Tests/JobsRedisDriverTests/JobsRedisDriverTests.swift
+++ b/Tests/JobsRedisDriverTests/JobsRedisDriverTests.swift
@@ -71,7 +71,7 @@ final class JobsRedisDriverTests: XCTestCase {
         try app.start()
 
         try app.jobs.queue(.default)
-            .dispatch(Promise.self, "test")
+            .dispatch(Promise.self, .init(string: "test"))
             .wait()
 
         try XCTAssertEqual(promise.future.wait(), "test")
@@ -89,16 +89,20 @@ final class Promise: Job {
         self.promise.futureResult
     }
 
+    struct Message: Codable {
+        var string: String
+    }
+
     init(on eventLoop: EventLoop) {
         self.promise = eventLoop.makePromise()
     }
 
-    func dequeue(_ context: JobContext, _ message: String) -> EventLoopFuture<Void> {
-        self.promise.succeed(message)
+    func dequeue(_ context: JobContext, _ message: Message) -> EventLoopFuture<Void> {
+        self.promise.succeed(message.string)
         context.logger.info("promise succeeded \(message)")
         return context.eventLoop.makeSucceededFuture(())
     }
-    
+
     struct Deinit: Error { }
 
     deinit {


### PR DESCRIPTION
Adds a test to ensure that the `JobsCommand` boots correctly during `app.start` and correctly receives dispatched jobs.