### PR TITLE
Fixes delayed jobs being kept in the processing queue.

### DIFF
--- a/Sources/QueuesRedisDriver/JobsRedisDriver.swift
+++ b/Sources/QueuesRedisDriver/JobsRedisDriver.swift
@@ -166,7 +166,7 @@ extension _QueuesRedisQueue: Queue {
     
     func push(_ id: JobIdentifier) -> EventLoopFuture<Void> {
         self.client.lpush(RedisKey(id.string), into: RedisKey(self.key))
-            .map { _ in }
+            .flatMap { _ in self.lrem(RedisKey(id.string), from: RedisKey(self.processingKey)).transform(to: ()) }
     }
     
     func pop() -> EventLoopFuture<JobIdentifier?> {

--- a/Tests/QueuesRedisDriverTests/JobsRedisDriverTests.swift
+++ b/Tests/QueuesRedisDriverTests/JobsRedisDriverTests.swift
@@ -82,6 +82,14 @@ final class JobsRedisDriverTests: XCTestCase {
         
         XCTAssertEqual(dict["jobName"] as! String, "DelayedJob")
         XCTAssertEqual(dict["delayUntil"] as! Int, 1609477200)
+        
+        // Verify that a delayed job isn't still in processing after it's been put back in the queue
+        try app.queues.queue.worker.run().wait()
+        
+        let value = try redis.get(RedisKey("vapor_queues[default]-processing"), as: [String].self).wait()
+        let originalQueue = try redis.get(RedisKey("vapor_queues[default]"), as: [String].self).wait()
+        XCTAssertNil(value)
+        XCTAssertNil(originalQueue?.first, jobId.string)
     }
 }
 


### PR DESCRIPTION
Pushing delayed jobs back into the queue should also remove them from the processing queue.

<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
