### PR TITLE
Use `context.eventLoop` for executing redis commands

### DIFF
--- a/Sources/QueuesRedisDriver/JobsRedisDriver.swift
+++ b/Sources/QueuesRedisDriver/JobsRedisDriver.swift
@@ -102,6 +102,10 @@ extension _QueuesRedisQueue: RedisClient {
         return true
     }
     
+    var eventLoop: EventLoop {
+        self.context.eventLoop
+    }
+    
     func send(command: String, with arguments: [RESPValue]) -> EventLoopFuture<RESPValue> {
         self.client.send(command: command, with: arguments)
     }


### PR DESCRIPTION
Adds full conformance to the `RedisClient` protocol to use the context's eventLoop for commands vs the default `RedisConnectionPool`s `RedisConnection` eventLoop for commands.
