### PR TITLE
Update swift tools version to 5.8

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.8
 import PackageDescription
 
 let package = Package(

--- a/README.md
+++ b/README.md
@@ -19,9 +19,6 @@
         <img src="https://github.com/vapor/queues-redis-driver/actions/workflows/test.yml/badge.svg?event=push" alt="Continuous Integration">
     </a>
     <a href="https://swift.org">
-        <img src="http://img.shields.io/badge/swift-5.6-brightgreen.svg" alt="Swift 5.6">
-    </a>
-    <a href="https://swift.org">
         <img src="http://img.shields.io/badge/swift-5.8-brightgreen.svg" alt="Swift 5.8">
     </a>
 </p>


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

As of [queues 1.15](https://github.com/vapor/queues/releases/tag/1.15.0), swift 5.8 is required to build. This package is still on 5.6, and vapor itself is also on 5.8.

Also updates the README accordingly.
